### PR TITLE
Handle missing Redis sentinel port

### DIFF
--- a/backend/open_webui/test/util/test_redis.py
+++ b/backend/open_webui/test/util/test_redis.py
@@ -6,6 +6,7 @@ from open_webui.utils.redis import (
     parse_redis_service_url,
     get_redis_connection,
     get_sentinels_from_env,
+    get_sentinel_url_from_env,
     MAX_RETRY_COUNT,
 )
 import inspect
@@ -55,6 +56,23 @@ class TestSentinelRedisProxy:
         """Test empty sentinel hosts"""
         result = get_sentinels_from_env(None, "26379")
         assert result == []
+
+    def test_get_sentinels_from_env_default_port(self):
+        """Missing port should fall back to default 26379"""
+        hosts = "sentinel1,sentinel2"
+        result = get_sentinels_from_env(hosts, None)
+        expected = [("sentinel1", 26379), ("sentinel2", 26379)]
+        assert result == expected
+
+    def test_get_sentinel_url_from_env_default_port(self):
+        """Missing port should fall back to default 26379 when building URL"""
+        redis_url = "redis://user:pass@mymaster:6379/0"
+        hosts = "sentinel1,sentinel2"
+        result = get_sentinel_url_from_env(redis_url, hosts, None)
+        expected = (
+            "redis+sentinel://user:pass@sentinel1:26379,sentinel2:26379/0/mymaster"
+        )
+        assert result == expected
 
     @patch("redis.sentinel.Sentinel")
     def test_sentinel_redis_proxy_sync_success(self, mock_sentinel_class):

--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -7,6 +7,10 @@ import redis
 
 from open_webui.env import REDIS_SENTINEL_MAX_RETRY_COUNT
 
+# Maintain backward compatibility with the previous constant name
+# used throughout the codebase and tests.
+MAX_RETRY_COUNT = REDIS_SENTINEL_MAX_RETRY_COUNT
+
 log = logging.getLogger(__name__)
 
 
@@ -191,7 +195,10 @@ def get_redis_connection(
 def get_sentinels_from_env(sentinel_hosts_env, sentinel_port_env):
     if sentinel_hosts_env:
         sentinel_hosts = sentinel_hosts_env.split(",")
-        sentinel_port = int(sentinel_port_env)
+        try:
+            sentinel_port = int(sentinel_port_env)
+        except (TypeError, ValueError):
+            sentinel_port = 26379
         return [(host, sentinel_port) for host in sentinel_hosts]
     return []
 
@@ -203,7 +210,11 @@ def get_sentinel_url_from_env(redis_url, sentinel_hosts_env, sentinel_port_env):
     auth_part = ""
     if username or password:
         auth_part = f"{username}:{password}@"
+    try:
+        sentinel_port = int(sentinel_port_env)
+    except (TypeError, ValueError):
+        sentinel_port = 26379
     hosts_part = ",".join(
-        f"{host}:{sentinel_port_env}" for host in sentinel_hosts_env.split(",")
+        f"{host}:{sentinel_port}" for host in sentinel_hosts_env.split(",")
     )
     return f"redis+sentinel://{auth_part}{hosts_part}/{redis_config['db']}/{redis_config['service']}"


### PR DESCRIPTION
## Summary
- ensure Redis sentinel helpers fall back to default port when environment variable missing
- re-export `MAX_RETRY_COUNT` for backward compatibility
- test missing sentinel port parsing and URL generation

## Testing
- `PYTHONPATH=backend pytest backend/open_webui/test/util/test_redis.py::TestSentinelRedisProxy::test_get_sentinels_from_env_default_port -q`
- `PYTHONPATH=backend pytest backend/open_webui/test/util/test_redis.py::TestSentinelRedisProxy::test_get_sentinel_url_from_env_default_port -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4a64ea488327b5dccbda1fafad1e